### PR TITLE
Update test now that Core now ignores equal variable redefinitions.

### DIFF
--- a/src/test/WixToolsetTest.BuildTasks/TestData/SimpleMsiPackage/MsiPackage/Package.wxs
+++ b/src/test/WixToolsetTest.BuildTasks/TestData/SimpleMsiPackage/MsiPackage/Package.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <?define Variable = "Value" ?>
-<?define Variable = "Value" ?>
+<?define Variable = "DifferentValue" ?>
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Product Id="*" Name="MsiPackage" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">


### PR DESCRIPTION
Depends on https://github.com/wixtoolset/Core/pull/2