### PR TITLE
Handle the rename of WixCA and QtExec* binary, CA, and property ids.

### DIFF
--- a/src/test/WixToolsetTest.WixCop/TestData/QtExec.bad/v3.wxs
+++ b/src/test/WixToolsetTest.WixCop/TestData/QtExec.bad/v3.wxs
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+
+<?include WixVer.wxi ?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:swid="http://schemas.microsoft.com/wix/TagExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+    <Product Id="*" Name="!(loc.ShortProduct) v$(var.WixMajorMinor) Core" Language="1033" Manufacturer="!(loc.Company)"
+             Version="$(var.WixMsiProductVersion)" UpgradeCode="3618724B-2523-44F9-A908-866AA619504D">
+        <Package Compressed="yes" InstallerVersion="200" SummaryCodepage="1252" InstallScope="perMachine" />
+        <swid:Tag Regid="!(loc.Regid)" InstallDirectory="INSTALLFOLDER" />
+
+        <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed." />
+
+        <MediaTemplate CabinetTemplate="core{0}.cab" />
+
+        <Property Id="QtExecCmdTimeout" Value="600000" />
+        <CustomAction Id="InstallVSTemplateCommand" Property="QtExecCmdLine" Value="&quot;[VSENVPRODUCT80]\devenv.exe&quot; /setup" />
+        <CustomAction Id="InstallVSTemplate" BinaryKey="WixCA" DllEntry="CAQuietExec" Return="asyncWait" />
+
+        <Feature Id="Feature_WiX" Title="WiX Toolset" Level="1">
+            <Component Id="Licensing" Directory="INSTALLFOLDER">
+                <File Source="LICENSE.TXT" />
+            </Component>
+
+            <Component Id="ProductRegistration" Directory="INSTALLFOLDER">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajorMinor)">
+                    <RegistryValue Name="InstallFolder" Value="[INSTALLFOLDER]" Type="string" />
+                </RegistryKey>
+            </Component>
+
+            <Component Id="ProductFamilyRegistration" Directory="INSTALLFOLDER">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajor).x">
+                    <RegistryValue Name="v$(var.WixMajorMinor)" Value="[INSTALLFOLDER]" Type="string" />
+                </RegistryKey>
+            </Component>
+
+            <Component Id="ProductInformation" Directory="BinFolder">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajorMinor)">
+                    <RegistryValue Name="InstallRoot" Value="[BinFolder]" Type="string"/>
+                    <RegistryValue Name="ProductVersion" Value="[ProductVersion]" Type="string" />
+                </RegistryKey>
+
+                <RemoveFolder Id="CleanupShortcutFolder" Directory="ShortcutFolder" On="uninstall" />
+            </Component>
+
+            <Component Directory="BinFolder">
+                <File Source="common\wixtoolset.org.ico" />
+                <util:InternetShortcut Id="wixtoolset.org" Directory="ShortcutFolder" Name="WiX Home Page" Target="http://wixtoolset.org/" IconFile="file://[#wixtoolset.org.ico]" />
+            </Component>
+
+            <ComponentGroupRef Id="ToolsetComponents" />
+            <ComponentGroupRef Id="ExtensionComponents" />
+            <ComponentGroupRef Id="LuxComponents" />
+            <ComponentGroupRef Id="DocComponents" />
+        </Feature>
+
+        <FeatureRef Id="Feature_MSBuild" />
+        <FeatureRef Id="Feature_Intellisense2010" />
+        <FeatureRef Id="Feature_Intellisense2012" />
+        <FeatureRef Id="Feature_Intellisense2013" />
+        <FeatureRef Id="Feature_Intellisense2015" />
+    </Product>
+</Wix>

--- a/src/test/WixToolsetTest.WixCop/TestData/QtExec.bad/v4_expected.wxs
+++ b/src/test/WixToolsetTest.WixCop/TestData/QtExec.bad/v4_expected.wxs
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+
+<?include WixVer.wxi ?>
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:swid="http://wixtoolset.org/schemas/v4/wxs/tag" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+    <Product Id="*" Name="!(loc.ShortProduct) v$(var.WixMajorMinor) Core" Language="1033" Manufacturer="!(loc.Company)" Version="$(var.WixMsiProductVersion)" UpgradeCode="3618724B-2523-44F9-A908-866AA619504D">
+        <Package Compressed="yes" InstallerVersion="200" SummaryCodepage="1252" InstallScope="perMachine" />
+        <swid:Tag Regid="!(loc.Regid)" InstallDirectory="INSTALLFOLDER" />
+
+        <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed." />
+
+        <MediaTemplate CabinetTemplate="core{0}.cab" />
+
+        <Property Id="QtExecCmdTimeout" Value="600000" />
+        <CustomAction Id="InstallVSTemplateCommand" Property="WixQuietExecCmdLine" Value="&quot;[VSENVPRODUCT80]\devenv.exe&quot; /setup" />
+        <CustomAction Id="InstallVSTemplate" BinaryKey="UtilCA" DllEntry="WixQuietExec" Return="asyncWait" />
+
+        <Feature Id="Feature_WiX" Title="WiX Toolset" Level="1">
+            <Component Id="Licensing" Directory="INSTALLFOLDER">
+                <File Id="LICENSE.TXT" Source="LICENSE.TXT" />
+            </Component>
+
+            <Component Id="ProductRegistration" Directory="INSTALLFOLDER">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajorMinor)">
+                    <RegistryValue Name="InstallFolder" Value="[INSTALLFOLDER]" Type="string" />
+                </RegistryKey>
+            </Component>
+
+            <Component Id="ProductFamilyRegistration" Directory="INSTALLFOLDER">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajor).x">
+                    <RegistryValue Name="v$(var.WixMajorMinor)" Value="[INSTALLFOLDER]" Type="string" />
+                </RegistryKey>
+            </Component>
+
+            <Component Id="ProductInformation" Directory="BinFolder">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajorMinor)">
+                    <RegistryValue Name="InstallRoot" Value="[BinFolder]" Type="string" />
+                    <RegistryValue Name="ProductVersion" Value="[ProductVersion]" Type="string" />
+                </RegistryKey>
+
+                <RemoveFolder Id="CleanupShortcutFolder" Directory="ShortcutFolder" On="uninstall" />
+            </Component>
+
+            <Component Directory="BinFolder">
+                <File Id="wixtoolset.org.ico" Source="common\wixtoolset.org.ico" />
+                <util:InternetShortcut Id="wixtoolset.org" Directory="ShortcutFolder" Name="WiX Home Page" Target="http://wixtoolset.org/" IconFile="file://[#wixtoolset.org.ico]" />
+            </Component>
+
+            <ComponentGroupRef Id="ToolsetComponents" />
+            <ComponentGroupRef Id="ExtensionComponents" />
+            <ComponentGroupRef Id="LuxComponents" />
+            <ComponentGroupRef Id="DocComponents" />
+        </Feature>
+
+        <FeatureRef Id="Feature_MSBuild" />
+        <FeatureRef Id="Feature_Intellisense2010" />
+        <FeatureRef Id="Feature_Intellisense2012" />
+        <FeatureRef Id="Feature_Intellisense2013" />
+        <FeatureRef Id="Feature_Intellisense2015" />
+    </Product>
+</Wix>

--- a/src/test/WixToolsetTest.WixCop/TestData/QtExec/v3.wxs
+++ b/src/test/WixToolsetTest.WixCop/TestData/QtExec/v3.wxs
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+
+<?include WixVer.wxi ?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:swid="http://schemas.microsoft.com/wix/TagExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+    <Product Id="*" Name="!(loc.ShortProduct) v$(var.WixMajorMinor) Core" Language="1033" Manufacturer="!(loc.Company)"
+             Version="$(var.WixMsiProductVersion)" UpgradeCode="3618724B-2523-44F9-A908-866AA619504D">
+        <Package Compressed="yes" InstallerVersion="200" SummaryCodepage="1252" InstallScope="perMachine" />
+        <swid:Tag Regid="!(loc.Regid)" InstallDirectory="INSTALLFOLDER" />
+
+        <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed." />
+
+        <MediaTemplate CabinetTemplate="core{0}.cab" />
+
+        <CustomAction Id="InstallVSTemplateCommand" Property="QtExecCmdLine" Value="&quot;[VSENVPRODUCT80]\devenv.exe&quot; /setup" />
+        <CustomAction Id="InstallVSTemplate" BinaryKey="WixCA" DllEntry="CAQuietExec" Return="asyncWait" />
+
+        <Feature Id="Feature_WiX" Title="WiX Toolset" Level="1">
+            <Component Id="Licensing" Directory="INSTALLFOLDER">
+                <File Source="LICENSE.TXT" />
+            </Component>
+
+            <Component Id="ProductRegistration" Directory="INSTALLFOLDER">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajorMinor)">
+                    <RegistryValue Name="InstallFolder" Value="[INSTALLFOLDER]" Type="string" />
+                </RegistryKey>
+            </Component>
+
+            <Component Id="ProductFamilyRegistration" Directory="INSTALLFOLDER">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajor).x">
+                    <RegistryValue Name="v$(var.WixMajorMinor)" Value="[INSTALLFOLDER]" Type="string" />
+                </RegistryKey>
+            </Component>
+
+            <Component Id="ProductInformation" Directory="BinFolder">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajorMinor)">
+                    <RegistryValue Name="InstallRoot" Value="[BinFolder]" Type="string"/>
+                    <RegistryValue Name="ProductVersion" Value="[ProductVersion]" Type="string" />
+                </RegistryKey>
+
+                <RemoveFolder Id="CleanupShortcutFolder" Directory="ShortcutFolder" On="uninstall" />
+            </Component>
+
+            <Component Directory="BinFolder">
+                <File Source="common\wixtoolset.org.ico" />
+                <util:InternetShortcut Id="wixtoolset.org" Directory="ShortcutFolder" Name="WiX Home Page" Target="http://wixtoolset.org/" IconFile="file://[#wixtoolset.org.ico]" />
+            </Component>
+
+            <ComponentGroupRef Id="ToolsetComponents" />
+            <ComponentGroupRef Id="ExtensionComponents" />
+            <ComponentGroupRef Id="LuxComponents" />
+            <ComponentGroupRef Id="DocComponents" />
+        </Feature>
+
+        <FeatureRef Id="Feature_MSBuild" />
+        <FeatureRef Id="Feature_Intellisense2010" />
+        <FeatureRef Id="Feature_Intellisense2012" />
+        <FeatureRef Id="Feature_Intellisense2013" />
+        <FeatureRef Id="Feature_Intellisense2015" />
+    </Product>
+</Wix>

--- a/src/test/WixToolsetTest.WixCop/TestData/QtExec/v4_expected.wxs
+++ b/src/test/WixToolsetTest.WixCop/TestData/QtExec/v4_expected.wxs
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+
+<?include WixVer.wxi ?>
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:swid="http://wixtoolset.org/schemas/v4/wxs/tag" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+    <Product Id="*" Name="!(loc.ShortProduct) v$(var.WixMajorMinor) Core" Language="1033" Manufacturer="!(loc.Company)" Version="$(var.WixMsiProductVersion)" UpgradeCode="3618724B-2523-44F9-A908-866AA619504D">
+        <Package Compressed="yes" InstallerVersion="200" SummaryCodepage="1252" InstallScope="perMachine" />
+        <swid:Tag Regid="!(loc.Regid)" InstallDirectory="INSTALLFOLDER" />
+
+        <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed." />
+
+        <MediaTemplate CabinetTemplate="core{0}.cab" />
+
+        <CustomAction Id="InstallVSTemplateCommand" Property="WixQuietExecCmdLine" Value="&quot;[VSENVPRODUCT80]\devenv.exe&quot; /setup" />
+        <CustomAction Id="InstallVSTemplate" BinaryKey="UtilCA" DllEntry="WixQuietExec" Return="asyncWait" />
+
+        <Feature Id="Feature_WiX" Title="WiX Toolset" Level="1">
+            <Component Id="Licensing" Directory="INSTALLFOLDER">
+                <File Id="LICENSE.TXT" Source="LICENSE.TXT" />
+            </Component>
+
+            <Component Id="ProductRegistration" Directory="INSTALLFOLDER">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajorMinor)">
+                    <RegistryValue Name="InstallFolder" Value="[INSTALLFOLDER]" Type="string" />
+                </RegistryKey>
+            </Component>
+
+            <Component Id="ProductFamilyRegistration" Directory="INSTALLFOLDER">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajor).x">
+                    <RegistryValue Name="v$(var.WixMajorMinor)" Value="[INSTALLFOLDER]" Type="string" />
+                </RegistryKey>
+            </Component>
+
+            <Component Id="ProductInformation" Directory="BinFolder">
+                <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows Installer XML\$(var.WixMajorMinor)">
+                    <RegistryValue Name="InstallRoot" Value="[BinFolder]" Type="string" />
+                    <RegistryValue Name="ProductVersion" Value="[ProductVersion]" Type="string" />
+                </RegistryKey>
+
+                <RemoveFolder Id="CleanupShortcutFolder" Directory="ShortcutFolder" On="uninstall" />
+            </Component>
+
+            <Component Directory="BinFolder">
+                <File Id="wixtoolset.org.ico" Source="common\wixtoolset.org.ico" />
+                <util:InternetShortcut Id="wixtoolset.org" Directory="ShortcutFolder" Name="WiX Home Page" Target="http://wixtoolset.org/" IconFile="file://[#wixtoolset.org.ico]" />
+            </Component>
+
+            <ComponentGroupRef Id="ToolsetComponents" />
+            <ComponentGroupRef Id="ExtensionComponents" />
+            <ComponentGroupRef Id="LuxComponents" />
+            <ComponentGroupRef Id="DocComponents" />
+        </Feature>
+
+        <FeatureRef Id="Feature_MSBuild" />
+        <FeatureRef Id="Feature_Intellisense2010" />
+        <FeatureRef Id="Feature_Intellisense2012" />
+        <FeatureRef Id="Feature_Intellisense2013" />
+        <FeatureRef Id="Feature_Intellisense2015" />
+    </Product>
+</Wix>

--- a/src/test/WixToolsetTest.WixCop/WixCopFixture.cs
+++ b/src/test/WixToolsetTest.WixCop/WixCopFixture.cs
@@ -3,6 +3,7 @@
 namespace WixToolsetTest.WixCop
 {
     using System.IO;
+    using System.Linq;
     using WixBuildTools.TestSupport;
     using Xunit;
 
@@ -97,6 +98,99 @@ namespace WixToolsetTest.WixCop
                 var result2 = runner2.Execute();
 
                 Assert.Equal(0, result2.ExitCode);
+            }
+        }
+
+        [Fact]
+        public void CanConvertQtExec()
+        {
+            const string beforeFileName = "v3.wxs";
+            const string afterFileName = "v4_expected.wxs";
+            var folder = TestData.Get(@"TestData\QtExec");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder(true);
+                var targetFile = Path.Combine(baseFolder, beforeFileName);
+                File.Copy(Path.Combine(folder, beforeFileName), Path.Combine(baseFolder, beforeFileName));
+
+                var runner = new WixCopRunner
+                {
+                    FixErrors = true,
+                    SearchPatterns =
+                    {
+                        targetFile,
+                    },
+                };
+
+                var result = runner.Execute();
+
+                Assert.Equal(2, result.ExitCode);
+
+                var expected = File.ReadAllText(Path.Combine(folder, afterFileName)).Replace("\r\n", "\n");
+                var actual = File.ReadAllText(targetFile).Replace("\r\n", "\n");
+                Assert.Equal(expected, actual);
+
+                var runner2 = new WixCopRunner
+                {
+                    FixErrors = true,
+                    SearchPatterns =
+                    {
+                        targetFile,
+                    },
+                };
+
+                var result2 = runner2.Execute();
+
+                Assert.Equal(0, result2.ExitCode);
+            }
+        }
+
+        [Fact]
+        public void DetectUnconvertableQtExecCmdTimeout()
+        {
+            const string beforeFileName = "v3.wxs";
+            const string afterFileName = "v4_expected.wxs";
+            var folder = TestData.Get(@"TestData\QtExec.bad");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder(true);
+                var targetFile = Path.Combine(baseFolder, beforeFileName);
+                File.Copy(Path.Combine(folder, beforeFileName), Path.Combine(baseFolder, beforeFileName));
+
+                var runner = new WixCopRunner
+                {
+                    FixErrors = true,
+                    SearchPatterns =
+                    {
+                        targetFile,
+                    },
+                };
+
+                var result = runner.Execute();
+
+                Assert.Equal(2, result.ExitCode);
+
+                Assert.Single(result.Messages.Where(message => message.ToString().EndsWith("(QtExecCmdTimeoutAmbiguous)")));
+
+                var expected = File.ReadAllText(Path.Combine(folder, afterFileName)).Replace("\r\n", "\n");
+                var actual = File.ReadAllText(targetFile).Replace("\r\n", "\n");
+                Assert.Equal(expected, actual);
+
+                // still fails because QtExecCmdTimeoutAmbiguous is unfixable
+                var runner2 = new WixCopRunner
+                {
+                    FixErrors = true,
+                    SearchPatterns =
+                    {
+                        targetFile,
+                    },
+                };
+
+                var result2 = runner2.Execute();
+
+                Assert.Equal(2, result2.ExitCode);
             }
         }
     }

--- a/src/test/WixToolsetTest.WixCop/WixToolsetTest.WixCop.csproj
+++ b/src/test/WixToolsetTest.WixCop/WixToolsetTest.WixCop.csproj
@@ -18,6 +18,10 @@
     <Content Include="TestData\Preprocessor\ConvertedPreprocessor.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Preprocessor\Preprocessor.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\Preprocessor\wixcop.settings.xml" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\QtExec\v3.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\QtExec\v4_expected.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\QtExec.bad\v3.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\QtExec.bad\v4_expected.wxs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION


Fixed wixtoolset/issues#5887.