### PR TITLE
Make GenerateCompileWithObjectPath FIPS compliant

### DIFF
--- a/src/WixToolset.BuildTasks/GenerateCompileWithObjectPath.cs
+++ b/src/WixToolset.BuildTasks/GenerateCompileWithObjectPath.cs
@@ -62,9 +62,9 @@ namespace WixToolset.BuildTasks
             // hash the data
             byte[] hash;
 
-            using (MD5 md5 = new MD5CryptoServiceProvider())
+            using (SHA1 sha1 = new SHA1CryptoServiceProvider())
             {
-                hash = md5.ComputeHash(data);
+                hash = sha1.ComputeHash(data);
             }
 
             // build up the identifier


### PR DESCRIPTION
# Fixes https://github.com/wixtoolset/issues/issues/5672
- GenerateCompileWithObjectPath uses SHA1 instead of MD5 for ID generation