### PR TITLE
Set RuntimeIdentifier to win-x86 in most projects

### DIFF
--- a/src/ThmViewerPackage/ThmViewerPackage.wixproj
+++ b/src/ThmViewerPackage/ThmViewerPackage.wixproj
@@ -23,7 +23,7 @@
     </ProjectReference>
   </ItemGroup>
 
-  <Import Project="$(OutputPath)\net461\wix.targets" />
+  <Import Project="$(OutputPath)\net461\win-x86\wix.targets" />
 
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/WixToolset.BuildTasks/WixToolset.BuildTasks.csproj
+++ b/src/WixToolset.BuildTasks/WixToolset.BuildTasks.csproj
@@ -8,6 +8,7 @@
     <Title>WiX Toolset MSBuild Tasks</Title>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/dotnet-wix/dotnet-wix.csproj
+++ b/src/dotnet-wix/dotnet-wix.csproj
@@ -9,6 +9,7 @@
     <NuspecFile>$(MSBuildThisFileName).nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)publish\dotnet-wix\</NuspecBasePath>
     <NuspecProperties>Id=$(MSBuildThisFileName);Authors=$(Authors);Copyright=$(Copyright);Description=$(Description)</NuspecProperties>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/WixToolsetTest.BuildTasks/WixToolsetTest.BuildTasks.csproj
+++ b/src/test/WixToolsetTest.BuildTasks/WixToolsetTest.BuildTasks.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
     <DebugType>embedded</DebugType>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/WixToolsetTest.WixCop/WixToolsetTest.WixCop.csproj
+++ b/src/test/WixToolsetTest.WixCop/WixToolsetTest.WixCop.csproj
@@ -3,9 +3,10 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
     <DebugType>embedded</DebugType>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/wix/wix.csproj
+++ b/src/wix/wix.csproj
@@ -10,6 +10,7 @@
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- <PackAsTool>true</PackAsTool> -->
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/wixcop/WixCop.csproj
+++ b/src/wixcop/WixCop.csproj
@@ -10,6 +10,7 @@
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- <PackAsTool>true</PackAsTool> -->
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
now that the WixToolset.Core.Native package isn't providing wixnative.*.exe anymore.