### PR TITLE
Remove x86 restriction (introduced from last PR)

### DIFF
--- a/appveyor.cmd
+++ b/appveyor.cmd
@@ -9,8 +9,7 @@ dotnet test -c Release src\test\WixToolsetTest.WixCop
 
 dotnet publish -c Release -o %_P%\dotnet-wix\ -f netcoreapp2.1 src\wix
 dotnet publish -c Release -o %_P%\WixToolset.MSBuild\net461\ -f net461 src\WixToolset.BuildTasks
-dotnet publish -c Release -o %_P%\WixToolset.MSBuild\net472\ -f net472 src\WixToolset.BuildTasks
-dotnet publish -c Release -o %_P%\WixToolset.MSBuild\netstandard2.0\ -f netstandard2.0 src\WixToolset.BuildTasks
+dotnet publish -c Release -o %_P%\WixToolset.MSBuild\netcoreapp2.1\ -f netcoreapp2.1 src\WixToolset.BuildTasks
 
 @rem dotnet publish -c Release -o %_P%\netcoreapp2.1 -r win-x86 src\wix
 @rem dotnet publish -c Release -o %_P%\net461 -r win-x86 src\light

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ branches:
     - master
     - develop
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 version: 0.0.0.{build}
 configuration: Release

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="wixtoolset-burn" value="https://ci.appveyor.com/nuget/wixtoolset-burn" />
     <add key="wixtoolset-converters" value="https://ci.appveyor.com/nuget/wixtoolset-converters" />
     <add key="wixtoolset-core" value="https://ci.appveyor.com/nuget/wixtoolset-core" />
     <add key="wixtoolset-core-native" value="https://ci.appveyor.com/nuget/wixtoolset-core-native" />

--- a/src/WixToolset.BuildTasks/WixToolset.BuildTasks.csproj
+++ b/src/WixToolset.BuildTasks/WixToolset.BuildTasks.csproj
@@ -3,12 +3,13 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <Description></Description>
     <Title>WiX Toolset MSBuild Tasks</Title>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)'=='' and '$(TargetFramework)'!='netcoreapp2.1' ">win-x86</RuntimeIdentifier>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -36,8 +37,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="14.3" Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)'=='net472'" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.7.179" Condition="'$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="14.3" Condition="'$(TargetFramework)'=='net461'" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.7.179" Condition="'$(TargetFramework)'=='netcoreapp2.1' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WixToolset.MSBuild/WixToolset.MSBuild.csproj
+++ b/src/WixToolset.MSBuild/WixToolset.MSBuild.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Description>WiX Toolset MSBuild integration</Description>
     <NuspecFile>$(MSBuildThisFileName).nuspec</NuspecFile>

--- a/src/WixToolset.MSBuild/WixToolset.MSBuild.nuspec
+++ b/src/WixToolset.MSBuild/WixToolset.MSBuild.nuspec
@@ -13,7 +13,6 @@
   <files>
     <file src="$projectFolder$$id$.props" target="build" />
     <file src="net461\*" target="tools\net461" />
-    <file src="net472\*" target="tools\net472" />
-    <file src="netstandard2.0\*" target="tools\netstandard2.0" />
+    <file src="netcoreapp2.1\*" target="tools\netcoreapp2.1" />
   </files>
 </package>

--- a/src/WixToolset.MSBuild/WixToolset.MSBuild.props
+++ b/src/WixToolset.MSBuild/WixToolset.MSBuild.props
@@ -3,7 +3,7 @@
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
-    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\tools\netstandard2.0\wix.targets'))</WixTargetsPath>
+    <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\tools\netcoreapp2.1\wix.targets'))</WixTargetsPath>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\tools\net461\wix.targets'))</WixTargetsPath>
   </PropertyGroup>
 </Project>

--- a/src/dotnet-wix/dotnet-wix.csproj
+++ b/src/dotnet-wix/dotnet-wix.csproj
@@ -3,13 +3,12 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Description>WiX Toolset Command-line interface</Description>
     <NuspecFile>$(MSBuildThisFileName).nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)publish\dotnet-wix\</NuspecBasePath>
     <NuspecProperties>Id=$(MSBuildThisFileName);Authors=$(Authors);Copyright=$(Copyright);Description=$(Description)</NuspecProperties>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/WixToolsetTest.BuildTasks/TestData/SimpleMsiPackage/SimpleBundle/Bundle.wxs
+++ b/src/test/WixToolsetTest.BuildTasks/TestData/SimpleMsiPackage/SimpleBundle/Bundle.wxs
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Bundle Name="SimpleBundle" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="6670d5c9-bbec-4828-ab60-4a1c0ffeb97d">
+        <BootstrapperApplication SourceFile="test.txt" />
+
+        <Chain>
+            <ExePackage SourceFile="test.txt" /> 
+        </Chain>
+    </Bundle>
+</Wix>

--- a/src/test/WixToolsetTest.BuildTasks/TestData/SimpleMsiPackage/SimpleBundle/SimpleBundle.wixproj
+++ b/src/test/WixToolsetTest.BuildTasks/TestData/SimpleMsiPackage/SimpleBundle/SimpleBundle.wixproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ProjectGuid>6670d5c9-bbec-4828-ab60-4a1c0ffeb97d</ProjectGuid>
+    <OutputType>Bundle</OutputType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformName>$(Platform)</PlatformName>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformName>$(Platform)</PlatformName>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <PlatformName>$(Platform)</PlatformName>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <PlatformName>$(Platform)</PlatformName>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Bundle.wxs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <BindInputPaths Include="..\MsiPackage\data" />
+  </ItemGroup>
+
+  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath32)\WixToolset\v4.x\wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\WixToolset\v4.x\wix.targets') " />
+  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
+    <Error Text="WiX Toolset build tools (v4.0 or later) must be installed to build this project. To download the WiX Toolset, go to http://wixtoolset.org/releases/." />
+  </Target>
+</Project>

--- a/src/test/WixToolsetTest.BuildTasks/TestData/SimpleMsiPackage/SimpleMsiPackage.sln
+++ b/src/test/WixToolsetTest.BuildTasks/TestData/SimpleMsiPackage/SimpleMsiPackage.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.8
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "MsiPackage", "MsiPackage\MsiPackage.wixproj", "{7FB77005-C6E0-454F-8C2D-0A4A79C918BA}"
+EndProject
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "SimpleBundle", "SimpleBundle\SimpleBundle.wixproj", "{6670D5C9-BBEC-4828-AB60-4A1C0FFEB97D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,12 @@ Global
 		{7FB77005-C6E0-454F-8C2D-0A4A79C918BA}.Release|x64.Build.0 = Release|x64
 		{7FB77005-C6E0-454F-8C2D-0A4A79C918BA}.Release|x86.ActiveCfg = Release|x86
 		{7FB77005-C6E0-454F-8C2D-0A4A79C918BA}.Release|x86.Build.0 = Release|x86
+		{6670D5C9-BBEC-4828-AB60-4A1C0FFEB97D}.Debug|x64.ActiveCfg = Debug|x86
+		{6670D5C9-BBEC-4828-AB60-4A1C0FFEB97D}.Debug|x86.ActiveCfg = Debug|x86
+		{6670D5C9-BBEC-4828-AB60-4A1C0FFEB97D}.Debug|x86.Build.0 = Debug|x86
+		{6670D5C9-BBEC-4828-AB60-4A1C0FFEB97D}.Release|x64.ActiveCfg = Release|x86
+		{6670D5C9-BBEC-4828-AB60-4A1C0FFEB97D}.Release|x86.ActiveCfg = Release|x86
+		{6670D5C9-BBEC-4828-AB60-4A1C0FFEB97D}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/test/WixToolsetTest.BuildTasks/WixToolsetTest.BuildTasks.csproj
+++ b/src/test/WixToolsetTest.BuildTasks/WixToolsetTest.BuildTasks.csproj
@@ -23,6 +23,8 @@
     <Content Include="TestData\SimpleMsiPackage\MsiPackage\Package.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\SimpleMsiPackage\MsiPackage\PackageComponents.wxs" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestData\SimpleMsiPackage\MsiPackage\data\test.txt" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\SimpleMsiPackage\SimpleBundle\Bundle.wxs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestData\SimpleMsiPackage\SimpleBundle\SimpleBundle.wixproj" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wix/wix.csproj
+++ b/src/wix/wix.csproj
@@ -10,7 +10,8 @@
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- <PackAsTool>true</PackAsTool> -->
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)'=='' and '$(TargetFramework)'!='netcoreapp2.1' ">win-x86</RuntimeIdentifier>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/wixcop/WixCop.csproj
+++ b/src/wixcop/WixCop.csproj
@@ -10,7 +10,8 @@
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- <PackAsTool>true</PackAsTool> -->
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)'=='' and '$(TargetFramework)'!='netcoreapp2.1' ">win-x86</RuntimeIdentifier>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Remove unused net472 BuildTasks.
Make BuildTasks target netcoreapp instead of netstandard since publishing isn't supported for netstandard.
Add test for building a bundle from .wixproj.