### PR TITLE
Linux build fixes

### DIFF
--- a/src/WixToolset.BuildTasks/WixToolset.BuildTasks.csproj
+++ b/src/WixToolset.BuildTasks/WixToolset.BuildTasks.csproj
@@ -2,8 +2,13 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <Description></Description>
     <Title>WiX Toolset MSBuild Tasks</Title>
     <DebugType>embedded</DebugType>

--- a/src/heat/heat.csproj
+++ b/src/heat/heat.csproj
@@ -2,8 +2,13 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFrameworks>netcoreapp2.1;net461;net472</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>Harvester</Description>
     <Title>WiX Harvester</Title>

--- a/src/test/WixToolsetTest.BuildTasks/WixToolsetTest.BuildTasks.csproj
+++ b/src/test/WixToolsetTest.BuildTasks/WixToolsetTest.BuildTasks.csproj
@@ -2,8 +2,13 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <DebugType>embedded</DebugType>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>

--- a/src/test/WixToolsetTest.Sdk/WixToolsetTest.Sdk.csproj
+++ b/src/test/WixToolsetTest.Sdk/WixToolsetTest.Sdk.csproj
@@ -2,8 +2,13 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <DebugType>embedded</DebugType>
   </PropertyGroup>

--- a/src/wix/wix.csproj
+++ b/src/wix/wix.csproj
@@ -2,8 +2,13 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFrameworks>netcoreapp2.1;net461;net472</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>Compiler</Description>
     <Title>WiX Toolset Compiler</Title>


### PR DESCRIPTION
This series of patches, together with wixtoolset/Core#165, enables me to build the `wix` binary using .Net Core on Linux (specifically Ubuntu 18.04). See wixtoolset/issues#4381.