### PR TITLE
6266 - Change workaround in Sdk.props to also work with MSBuild 16.8

### DIFF
--- a/src/WixToolset.Sdk/Sdk/Sdk.props
+++ b/src/WixToolset.Sdk/Sdk/Sdk.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework Condition=" '$(TargetFramework)' == '' ">netstandard2.0</TargetFramework>
+    <TargetFrameworkMoniker Condition=" '$(TargetFrameworkMoniker)' == '' ">.NETFramework,Version=v4.8</TargetFrameworkMoniker>
     <EnableDefaultItems Condition=" '$(EnableDefaultItems)' == '' ">true</EnableDefaultItems>
     <EnableDefaultCompileItems Condition=" '$(EnableDefaultCompileItems)' == '' ">true</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems Condition=" '$(EnableDefaultEmbeddedResourceItems)' == '' ">true</EnableDefaultEmbeddedResourceItems>


### PR DESCRIPTION
This requires the .NET 4.8 targeting pack to be installed.

Closes https://github.com/wixtoolset/issues/issues/6266.